### PR TITLE
Bump jackson.version in /client-springmvc/BrightIdeas

### DIFF
--- a/client-springmvc/BrightIdeas/pom.xml
+++ b/client-springmvc/BrightIdeas/pom.xml
@@ -16,7 +16,7 @@
 		<hibernate.version>5.4.0.Final</hibernate.version>
 		<servlet.port>8080</servlet.port>
 		<spring.version>5.0.0.RELEASE</spring.version>
-		<jackson.version>2.9.8</jackson.version>
+		<jackson.version>2.10.0</jackson.version>
 		<cglib.version>2.2.2</cglib.version>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.8 to 2.10.0.

Updates `jackson-core` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.8...jackson-core-2.10.0)

Updates `jackson-annotations` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-databind` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Signed-off-by: dependabot[bot] <support@github.com>